### PR TITLE
Some Tweaks to the extended authentication token handling

### DIFF
--- a/Neos.Flow/Classes/Security/Authentication/Token/PasswordToken.php
+++ b/Neos.Flow/Classes/Security/Authentication/Token/PasswordToken.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Security\Authentication\Token;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Security\Exception\InvalidAuthenticationStatusException;
 use Neos\Utility\ObjectAccess;
 
 /**
@@ -20,18 +21,15 @@ use Neos\Utility\ObjectAccess;
  */
 class PasswordToken extends AbstractToken implements PasswordTokenInterface
 {
+
+    private const DEFAULT_PASSWORD_POST_FIELD = '__authentication.Neos.Flow.Security.Authentication.Token.PasswordToken.password';
+
     /**
      * The password credentials
      * @var array
      * @Flow\Transient
      */
     protected $credentials = ['password' => ''];
-
-    /**
-     * @var \Neos\Flow\Utility\Environment
-     * @Flow\Inject
-     */
-    protected $environment;
 
     /**
      * Updates the password credential from the POST vars, if the POST parameters
@@ -42,16 +40,16 @@ class PasswordToken extends AbstractToken implements PasswordTokenInterface
      *
      * @param ActionRequest $actionRequest The current action request
      * @return void
+     * @throws InvalidAuthenticationStatusException
      */
     public function updateCredentials(ActionRequest $actionRequest)
     {
         if ($actionRequest->getHttpRequest()->getMethod() !== 'POST') {
             return;
         }
-
-        $postArguments = $actionRequest->getInternalArguments();
-        $password = ObjectAccess::getPropertyPath($postArguments, '__authentication.Neos.Flow.Security.Authentication.Token.PasswordToken.password');
-
+        $allArguments = array_merge($actionRequest->getArguments(), $actionRequest->getInternalArguments());
+        $passwordFieldName = $this->options['passwordPostField'] ?? self::DEFAULT_PASSWORD_POST_FIELD;
+        $password = ObjectAccess::getPropertyPath($allArguments, $passwordFieldName);
         if (!empty($password)) {
             $this->credentials['password'] = $password;
             $this->setAuthenticationStatus(self::AUTHENTICATION_NEEDED);

--- a/Neos.Flow/Classes/Security/Authentication/Token/PasswordToken.php
+++ b/Neos.Flow/Classes/Security/Authentication/Token/PasswordToken.php
@@ -18,7 +18,7 @@ use Neos\Utility\ObjectAccess;
 /**
  * An authentication token used for simple password authentication.
  */
-class PasswordToken extends AbstractToken
+class PasswordToken extends AbstractToken implements PasswordTokenInterface
 {
     /**
      * The password credentials
@@ -56,6 +56,14 @@ class PasswordToken extends AbstractToken
             $this->credentials['password'] = $password;
             $this->setAuthenticationStatus(self::AUTHENTICATION_NEEDED);
         }
+    }
+
+    /**
+     * @return string the password this token represents, or an empty string
+     */
+    public function getPassword(): string
+    {
+        return $this->credentials['password'] ?? '';
     }
 
     /**

--- a/Neos.Flow/Classes/Security/Authentication/Token/PasswordTokenInterface.php
+++ b/Neos.Flow/Classes/Security/Authentication/Token/PasswordTokenInterface.php
@@ -1,0 +1,26 @@
+<?php
+namespace Neos\Flow\Security\Authentication\Token;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Security\Authentication\TokenInterface;
+
+/**
+ * Interface for authentication tokens which only hold a password
+ */
+interface PasswordTokenInterface extends TokenInterface
+{
+
+    /**
+     * @return string The password this token represents
+     */
+    public function getPassword(): string;
+}

--- a/Neos.Flow/Classes/Security/Authentication/Token/UsernamePassword.php
+++ b/Neos.Flow/Classes/Security/Authentication/Token/UsernamePassword.php
@@ -19,7 +19,7 @@ use Neos\Utility\ObjectAccess;
 /**
  * An authentication token used for simple username and password authentication.
  */
-class UsernamePassword extends AbstractToken implements UsernamePasswordInterface
+class UsernamePassword extends AbstractToken implements UsernamePasswordTokenInterface
 {
     private const DEFAULT_USERNAME_POST_FIELD = '__authentication.Neos.Flow.Security.Authentication.Token.UsernamePassword.username';
     private const DEFAULT_PASSWORD_POST_FIELD = '__authentication.Neos.Flow.Security.Authentication.Token.UsernamePassword.password';
@@ -67,10 +67,11 @@ class UsernamePassword extends AbstractToken implements UsernamePasswordInterfac
         if ($httpRequest->getMethod() !== 'POST') {
             return;
         }
-
-        $username = $this->getUsername();
-        $password = $this->getPassword();
-
+        $allArguments = array_merge($actionRequest->getArguments(), $actionRequest->getInternalArguments());
+        $usernameFieldName = $this->options['usernamePostField'] ?? self::DEFAULT_USERNAME_POST_FIELD;
+        $passwordFieldName = $this->options['passwordPostField'] ?? self::DEFAULT_PASSWORD_POST_FIELD;
+        $username = ObjectAccess::getPropertyPath($allArguments, $usernameFieldName);
+        $password = ObjectAccess::getPropertyPath($allArguments, $passwordFieldName);
         if (!empty($username) && !empty($password)) {
             $this->credentials['username'] = $username;
             $this->credentials['password'] = $password;
@@ -78,16 +79,20 @@ class UsernamePassword extends AbstractToken implements UsernamePasswordInterfac
         }
     }
 
+    /**
+     * @return string The username this token extracted from the request, or an empty string
+     */
     public function getUsername(): string
     {
-        $arguments = array_merge($this->actionRequest->getArguments(), $this->actionRequest->getInternalArguments());
-        return ObjectAccess::getPropertyPath($arguments, $this->options['usernamePostField'] ?? self::DEFAULT_USERNAME_POST_FIELD);
+        return $this->credentials['username'] ?? '';
     }
 
+    /**
+     * @return string The password this token extracted from the request, or an empty string
+     */
     public function getPassword(): string
     {
-        $arguments = array_merge($this->actionRequest->getArguments(), $this->actionRequest->getInternalArguments());
-        return ObjectAccess::getPropertyPath($arguments, $this->options['passwordPostField'] ?? self::DEFAULT_PASSWORD_POST_FIELD);
+        return $this->credentials['password'] ?? '';
     }
 
     /**

--- a/Neos.Flow/Classes/Security/Authentication/Token/UsernamePasswordTokenInterface.php
+++ b/Neos.Flow/Classes/Security/Authentication/Token/UsernamePasswordTokenInterface.php
@@ -11,12 +11,20 @@ namespace Neos\Flow\Security\Authentication\Token;
  * source code.
  */
 
+use Neos\Flow\Security\Authentication\TokenInterface;
+
 /**
- * Marker interface for authentication tokens which hold a username and password
+ * Interface for authentication tokens which hold a username and password
  */
-interface UsernamePasswordInterface
+interface UsernamePasswordTokenInterface extends TokenInterface
 {
+    /**
+     * @return string The username this token represents
+     */
     public function getUsername(): string;
 
+    /**
+     * @return string The password this token represents
+     */
     public function getPassword(): string;
 }

--- a/Neos.Flow/Classes/Security/Authentication/TokenAndProviderFactory.php
+++ b/Neos.Flow/Classes/Security/Authentication/TokenAndProviderFactory.php
@@ -172,7 +172,7 @@ class TokenAndProviderFactory implements TokenAndProviderFactoryInterface
                 /** @noinspection PhpMethodParametersCountMismatchInspection */
                 $tokenInstance = $this->objectManager->get($tokenClassName, $providerConfiguration['tokenOptions'] ?? []);
                 if (!$tokenInstance instanceof TokenInterface) {
-                    throw new Exception\InvalidAuthenticationProviderException('TODO', 1585921152);
+                    throw new Exception\InvalidAuthenticationProviderException(sprintf('The specified token is not an instance of %s but a %s. Please adjust the "token" configuration of the "%s" authentication provider', TokenInterface::class, is_object($tokenInstance) ? get_class($tokenInstance) : gettype($tokenInstance), $providerName), 1585921152);
                 }
                 $tokenInstance->setAuthenticationProviderName($providerName);
                 $this->tokens[] = $tokenInstance;

--- a/Neos.Flow/Configuration/Objects.yaml
+++ b/Neos.Flow/Configuration/Objects.yaml
@@ -554,6 +554,12 @@ Neos\Flow\Security\Authentication\Provider\TestingProvider:
     1:
       value: 'TestingProvider'
 
+Neos\Flow\Security\Authentication\Token\UsernamePasswordTokenInterface:
+  className: 'Neos\Flow\Security\Authentication\Token\UsernamePassword'
+
+Neos\Flow\Security\Authentication\Token\PasswordTokenInterface:
+  className: 'Neos\Flow\Security\Authentication\Token\PasswordToken'
+
 #                                                                          #
 # Session                                                                  #
 #                                                                          #


### PR DESCRIPTION
* Rename `UsernamePasswordInterface` to `UsernamePasswordTokenInterface` and make
  it extend the existing `TokenInterface`
* Adjust affected Providers so that they only specify the interface of the
  tokens they support
* Adjust `TokenAndProviderFactory` such that it can deal with the interface
  creation
* Introduce `PasswordTokenInterface` in the same manner