### PR TITLE
BUGFIX: Parse tags and annotations correctly for reflection

### DIFF
--- a/Neos.Flow/Classes/Reflection/DocCommentParser.php
+++ b/Neos.Flow/Classes/Reflection/DocCommentParser.php
@@ -115,7 +115,7 @@ class DocCommentParser
     protected function parseTag($line)
     {
         $tagAndValue = [];
-        if (preg_match('/@[A-Za-z0-9\\\\]+\\\\([A-Za-z0-9]+)(?:\\((.*)\\))?$/', $line, $tagAndValue) === 0) {
+        if (preg_match('/(@[A-Za-z0-9\\\\]+\\\\[A-Za-z0-9]+)(?:(?:\\(|\s)([^\)]*))?/', $line, $tagAndValue) === 0) {
             $tagAndValue = preg_split('/\s/', $line, 2);
         } else {
             array_shift($tagAndValue);


### PR DESCRIPTION
WIP: Handles all test cases in the issue correctly, but will behave weird with a closing bracket somewhere inside the annotation arguments or the comment

References https://github.com/neos/flow-development-collection/pull/2615